### PR TITLE
Remove the downloaded zip in the postinstall

### DIFF
--- a/Other/Update/Postinstall.ps1
+++ b/Other/Update/Postinstall.ps1
@@ -1,0 +1,6 @@
+# Run the post-install script
+# basically only cleanup the downloaded zip
+
+Get-ChildItem $DownloadDir -Filter '*.zip' | Foreach-Object {
+  Remove-Item $_.FullName
+}


### PR DESCRIPTION
Summary:
  * Remove the `cmder.zip` files after unpacking
    to ensure the latest version is downloaded.